### PR TITLE
feat: add support for efs disks

### DIFF
--- a/custom_components/beszel-api/__init__.py
+++ b/custom_components/beszel-api/__init__.py
@@ -13,12 +13,11 @@ async def async_setup_entry(hass, entry):
     username = entry.data[CONF_USERNAME]
     password = entry.data[CONF_PASSWORD]
     client = BeszelApiClient(url, username, password)
-    client.login()
 
     async def async_update_data():
         try:
             systems = await hass.async_add_executor_job(client.get_systems)
-
+            
             # Fetch system stats for each system
             for system in systems:
                 stats = await hass.async_add_executor_job(client.get_system_stats, system.id)
@@ -27,7 +26,7 @@ async def async_setup_entry(hass, entry):
                     system.stats = stats.stat if hasattr(stats, 'stat') else {}
                 else:
                     system.stats = {}
-
+            
             return systems
         except Exception as err:
             raise UpdateFailed(f"Error fetching systems: {err}")

--- a/custom_components/beszel-api/__init__.py
+++ b/custom_components/beszel-api/__init__.py
@@ -17,7 +17,18 @@ async def async_setup_entry(hass, entry):
 
     async def async_update_data():
         try:
-            return await hass.async_add_executor_job(client.get_systems)
+            systems = await hass.async_add_executor_job(client.get_systems)
+
+            # Fetch system stats for each system
+            for system in systems:
+                stats = await hass.async_add_executor_job(client.get_system_stats, system.id)
+                if stats:
+                    # Attach the stats data to the system object
+                    system.stats = stats.stat if hasattr(stats, 'stat') else {}
+                else:
+                    system.stats = {}
+
+            return systems
         except Exception as err:
             raise UpdateFailed(f"Error fetching systems: {err}")
 

--- a/custom_components/beszel-api/api.py
+++ b/custom_components/beszel-api/api.py
@@ -1,4 +1,7 @@
 from pocketbase import PocketBase
+import logging
+
+LOGGER = logging.getLogger(__name__)
 
 class BeszelApiClient:
     def __init__(self, url, username, password):
@@ -10,13 +13,21 @@ class BeszelApiClient:
     def _ensure_client(self):
         """Initialize the PocketBase client if not already done"""
         if self._client is None:
-            self._client = PocketBase(self._url)
-            self._client.collection("users").auth_with_password(self._username, self._password)
+            try:
+                self._client = PocketBase(self._url)
+                self._client.collection("users").auth_with_password(self._username, self._password)
+            except Exception as e:
+                LOGGER.error(f"Failed to initialize PocketBase client: {e}")
+                raise
 
     def get_systems(self):
-        self._ensure_client()
-        records = self._client.collection("systems").get_full_list()
-        return records
+        try:
+            self._ensure_client()
+            records = self._client.collection("systems").get_full_list()
+            return records
+        except Exception as e:
+            LOGGER.error(f"Failed to fetch systems: {e}")
+            raise
 
     def get_system_stats(self, system_id):
         """Get the latest system stats for a specific system"""
@@ -30,5 +41,6 @@ class BeszelApiClient:
                 return records.items[0]
             return None
         except Exception as e:
+            LOGGER.error(f"Failed to fetch stats for system {system_id}: {e}")
             # Return None if no stats found or error occurs
             return None

--- a/custom_components/beszel-api/api.py
+++ b/custom_components/beszel-api/api.py
@@ -7,17 +7,21 @@ class BeszelApiClient:
         self._password = password
         self._client = None
 
-    def login(self):
-        self._client = PocketBase(self._url)
-        self._client.collection("users").auth_with_password(self._username, self._password)
+    def _ensure_client(self):
+        """Initialize the PocketBase client if not already done"""
+        if self._client is None:
+            self._client = PocketBase(self._url)
+            self._client.collection("users").auth_with_password(self._username, self._password)
 
     def get_systems(self):
+        self._ensure_client()
         records = self._client.collection("systems").get_full_list()
         return records
 
     def get_system_stats(self, system_id):
         """Get the latest system stats for a specific system"""
         try:
+            self._ensure_client()
             # Get the latest record for the specific system
             records = self._client.collection("system_stats").get_list(
                 1, 1, {"filter": f"system = '{system_id}'", "sort": "-created"}

--- a/custom_components/beszel-api/api.py
+++ b/custom_components/beszel-api/api.py
@@ -14,3 +14,17 @@ class BeszelApiClient:
     def get_systems(self):
         records = self._client.collection("systems").get_full_list()
         return records
+
+    def get_system_stats(self, system_id):
+        """Get the latest system stats for a specific system"""
+        try:
+            # Get the latest record for the specific system
+            records = self._client.collection("system_stats").get_list(
+                1, 1, {"filter": f"system = '{system_id}'", "sort": "-created"}
+            )
+            if records.items:
+                return records.items[0]
+            return None
+        except Exception as e:
+            # Return None if no stats found or error occurs
+            return None

--- a/custom_components/beszel-api/binary_sensor.py
+++ b/custom_components/beszel-api/binary_sensor.py
@@ -5,7 +5,11 @@ from .const import DOMAIN
 async def async_setup_entry(hass, entry, async_add_entities):
     coordinator = hass.data[DOMAIN][entry.entry_id]
     entities = []
-    for system in coordinator.data:
+
+    # Get systems from coordinator data
+    systems = coordinator.data['systems']
+
+    for system in systems:
         entities.append(BeszelStatusBinarySensor(coordinator, system))
     async_add_entities(entities)
 
@@ -16,8 +20,8 @@ class BeszelStatusBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
     @property
     def system(self):
-        # Always return the latest system object by id
-        for s in self.coordinator.data:
+        systems = self.coordinator.data['systems']
+        for s in systems:
             if s.id == self._system_id:
                 return s
         return None

--- a/custom_components/beszel-api/sensor.py
+++ b/custom_components/beszel-api/sensor.py
@@ -8,13 +8,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     try:
         # Get systems and stats from coordinator data
-        if isinstance(coordinator.data, dict) and 'systems' in coordinator.data:
-            systems = coordinator.data['systems']
-            stats_data = coordinator.data.get('stats', {})
-        else:
-            # Fallback for old data format
-            systems = coordinator.data
-            stats_data = {}
+        systems = coordinator.data['systems']
+        stats_data = coordinator.data.get('stats', {})
 
         for system in systems:
             try:
@@ -51,13 +46,7 @@ class BeszelBaseSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def system(self):
-        # Handle new data structure where coordinator.data is a dict with 'systems' key
-        if isinstance(self.coordinator.data, dict) and 'systems' in self.coordinator.data:
-            systems = self.coordinator.data['systems']
-        else:
-            # Fallback for old data format
-            systems = self.coordinator.data
-
+        systems = self.coordinator.data['systems']
         for s in systems:
             if s.id == self._system_id:
                 return s


### PR DESCRIPTION
# Add EFS Disk Sensor Support

## Summary
Added support for EFS (External File System) disk sensors by fetching system stats from the `system_stats` collection and creating dedicated sensors for each EFS disk entry.

## Changes
- **New API method**: Added `get_system_stats()` to fetch latest stats records from `system_stats` collection
- **New sensor**: Created `BeszelEFSDiskSensor` class that calculates disk usage percentage from EFS data
- **Data structure refactor**: Modified coordinator to return both systems and stats data in a unified structure
- **Lazy initialization**: Moved PocketBase client initialization to prevent blocking calls in event loop
- **Platform updates**: Updated both sensor and binary_sensor platforms to work with new data structure

## Technical Details
- EFS sensors calculate usage percentage from `d` (total space) and `du` (used space) fields
- Provides additional attributes: total space, used space, read/write speeds
- Automatically creates sensors for each EFS disk found in system stats
- Fixed blocking I/O operations by using `async_add_executor_job`

## Files Modified
- `api.py`: Added system stats fetching and lazy client initialization
- `__init__.py`: Refactored coordinator data structure
- `sensor.py`: Added EFS disk sensor and updated data access
- `binary_sensor.py`: Updated to work with new data structure

## Testing
Only tested on my instance with a single Beszel system with one EFS disk