### PR TITLE
feat: add optional verify_ssl arg

### DIFF
--- a/custom_components/beszel-api/__init__.py
+++ b/custom_components/beszel-api/__init__.py
@@ -1,7 +1,7 @@
 import asyncio
 from datetime import timedelta
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from .const import DOMAIN, CONF_URL, CONF_USERNAME, CONF_PASSWORD, UPDATE_INTERVAL, LOGGER
+from .const import DOMAIN, CONF_URL, CONF_USERNAME, CONF_PASSWORD, CONF_VERIFY_SSL, UPDATE_INTERVAL, LOGGER
 from .api import BeszelApiClient
 
 PLATFORMS = ["sensor", "binary_sensor"]
@@ -12,7 +12,8 @@ async def async_setup_entry(hass, entry):
     url = entry.data[CONF_URL]
     username = entry.data.get(CONF_USERNAME, None)
     password = entry.data.get(CONF_PASSWORD, None)
-    client = BeszelApiClient(url, username, password)
+    verify_ssl = entry.data.get(CONF_VERIFY_SSL, True)
+    client = BeszelApiClient(url, username, password, verify_ssl)
 
     async def async_update_data():
         try:

--- a/custom_components/beszel-api/api.py
+++ b/custom_components/beszel-api/api.py
@@ -1,20 +1,31 @@
-from pocketbase import PocketBase
 import logging
+
+import httpx
+from pocketbase import PocketBase
 
 LOGGER = logging.getLogger(__name__)
 
+
 class BeszelApiClient:
-    def __init__(self, url, username: str | None = None, password: str | None = None):
+    def __init__(
+        self,
+        url,
+        username: str | None = None,
+        password: str | None = None,
+        verify_ssl: bool = True,
+    ):
         self._url = url.rstrip("/")
         self._username = username
         self._password = password
+        self._verify_ssl = verify_ssl
         self._client = None
 
     def _ensure_client(self):
         """Initialize the PocketBase client if not already done"""
         if self._client is None:
             try:
-                self._client = PocketBase(self._url)
+                httpx_client = httpx.Client(verify=self._verify_ssl)
+                self._client = PocketBase(self._url, http_client=httpx_client)
                 if self._username and self._password:
                     self._client.collection("users").auth_with_password(
                         self._username,

--- a/custom_components/beszel-api/config_flow.py
+++ b/custom_components/beszel-api/config_flow.py
@@ -1,6 +1,6 @@
 import voluptuous as vol
 from homeassistant import config_entries
-from .const import DOMAIN, CONF_URL, CONF_USERNAME, CONF_PASSWORD
+from .const import DOMAIN, CONF_URL, CONF_USERNAME, CONF_PASSWORD, CONF_VERIFY_SSL
 
 class BeszelConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
@@ -18,6 +18,7 @@ class BeszelConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required(CONF_URL): str,
                 vol.Optional(CONF_USERNAME): str,
                 vol.Optional(CONF_PASSWORD): str,
+                vol.Optional(CONF_VERIFY_SSL, default=True): bool,
             }),
             errors=errors,
         )

--- a/custom_components/beszel-api/const.py
+++ b/custom_components/beszel-api/const.py
@@ -4,5 +4,6 @@ DOMAIN = "beszel_api"
 CONF_URL = "url"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
+CONF_VERIFY_SSL = "verify_ssl"
 UPDATE_INTERVAL = 120
 LOGGER = logging.getLogger(__package__)


### PR DESCRIPTION
## Why
Introduce support for configuring SSL verification in Beszel API custom component. I use self-signed certs for local domains, which was breaking this integration in HA.

<img width="750" height="300" alt="Screenshot 2025-12-08 at 11-38-37 Settings – Home Assistant" src="https://github.com/user-attachments/assets/37275ea4-8bac-4e9a-acac-03f51f0fca1a" />

## Description
This pull request introduces support for configuring SSL verification in the Beszel API custom component. Users can now choose whether to verify SSL certificates when connecting to the API, improving flexibility for self-hosted or development environments. The changes are implemented across the configuration flow, constants, and API client initialization.

**Configuration changes:**

* Added a new configuration option `CONF_VERIFY_SSL` to allow users to specify whether SSL certificates should be verified. This option is available during setup and defaults to `True`. 

**API client changes:**

* Updated the `BeszelApiClient` class to accept a `verify_ssl` parameter and use it when creating the underlying `httpx.Client`, ensuring SSL verification behavior matches user configuration.
* Modified the initialization in `async_setup_entry` to read the `verify_ssl` setting from configuration and pass it to the API client.

## Other Notes

Tested my fork in HA with success:

<img width="250" height="250" alt="Screenshot 2025-12-08 at 11-36-32 Settings – Home Assistant" src="https://github.com/user-attachments/assets/9caacea3-7987-4472-91e8-1220f4da1041" />
<img width="750" height="400" alt="Screenshot 2025-12-08 at 11-42-42 Settings – Home Assistant" src="https://github.com/user-attachments/assets/11ce7880-b730-46e5-8b90-509079af7667" />

