### PR TITLE
add new S.M.A.R.T attributes

### DIFF
--- a/custom_components/beszel_api/__init__.py
+++ b/custom_components/beszel_api/__init__.py
@@ -62,6 +62,8 @@ async def async_setup_entry(hass, entry):
                             'type': getattr(device, 'type', ''),
                             'serial': getattr(device, 'serial', ''),
                             'firmware': getattr(device, 'firmware', ''),
+                            'attributes': getattr(device, 'attributes', []) or [],
+                            'updated': getattr(device, 'updated', None),
                         })
                 LOGGER.debug(f"Loaded S.M.A.R.T. data for {len(all_smart)} devices")
             except Exception as e:

--- a/custom_components/beszel_api/binary_sensor.py
+++ b/custom_components/beszel_api/binary_sensor.py
@@ -1,9 +1,56 @@
+import re
+
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorDeviceClass,
 )
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from .const import DOMAIN, LOGGER
+from .const import DOMAIN, LOGGER, SMART_CURATED_ATTRIBUTES
+
+
+def _normalize_smart_name(name: str) -> str:
+    normalized = name.strip()
+    if "_" not in normalized:
+        normalized = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", normalized)
+        normalized = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", normalized)
+    return (
+        normalized.lower()
+        .replace(" ", "_")
+        .replace(".", "")
+        .replace("-", "_")
+        .replace("/", "_")
+    )
+
+
+def _curated_smart_attributes(attributes: list) -> dict:
+    result = {}
+    failed = []
+
+    for attr in attributes:
+        name = attr.get("n")
+        if not name:
+            continue
+        if attr.get("wf"):
+            failed.append(name)
+
+        key = _normalize_smart_name(name)
+        if key not in SMART_CURATED_ATTRIBUTES:
+            continue
+
+        raw_string = attr.get("rs")
+        raw_value = attr.get("rv")
+        if raw_string not in (None, ""):
+            result[f"smart_{key}"] = raw_string
+        elif raw_value is not None:
+            result[f"smart_{key}"] = raw_value
+
+        if raw_value is not None:
+            result[f"smart_{key}_raw"] = raw_value
+
+    if failed:
+        result["failed_attributes"] = failed
+
+    return result
 
 async def async_setup_entry(hass, entry, async_add_entities):
     data = hass.data[DOMAIN][entry.entry_id]
@@ -202,8 +249,13 @@ class BeszelSmartBinarySensor(BeszelBaseBinarySensor):
         # Device path
         attributes['device'] = self._device_name
         
-        # Health state
         state = device_data.get('state', '')
         attributes['health_state'] = state
+
+        updated = device_data.get('updated')
+        if updated:
+            attributes['updated'] = updated
+
+        attributes.update(_curated_smart_attributes(device_data.get('attributes') or []))
 
         return attributes

--- a/custom_components/beszel_api/const.py
+++ b/custom_components/beszel_api/const.py
@@ -7,3 +7,36 @@ CONF_PASSWORD = "password"
 CONF_VERIFY_SSL = "verify_ssl"
 CONF_UPDATE_INTERVAL = "update_interval"
 LOGGER = logging.getLogger(__package__)
+
+SMART_CURATED_ATTRIBUTES = frozenset({
+    "ssd_life_left",
+    "percentage_used",
+    "wear_leveling_count",
+    "media_wearout_indicator",
+    "reallocated_sector_ct",
+    "reallocated_event_count",
+    "current_pending_sector",
+    "offline_uncorrectable",
+    "reported_uncorrect",
+    "udma_crc_error_count",
+    "sata_crc_error_count",
+    "crc_error_count",
+    "sata_phy_error_count",
+    "seek_error_rate",
+    "unsafe_shutdown_count",
+    "unsafe_shutdowns",
+    "flash_writes_gib",
+    "lifetime_writes_gib",
+    "lifetime_reads_gib",
+    "data_units_written",
+    "data_units_read",
+    "total_lbas_written",
+    "total_lbas_read",
+    "average_erase_count",
+    "max_erase_count",
+    "total_erase_count",
+    "load_cycle_count",
+    "start_stop_count",
+    "power_on_hours",
+    "temperature_celsius",
+})


### PR DESCRIPTION
## Summary
- Fetch `attributes` from Beszel `smart_devices` API
- Expose curated `smart_*` metrics on the existing SMART binary sensor
- Add `failed_attributes` for disks with failing SMART values (e.g. Airflow_Temperature_Cel)
## Notes
- No new entities — all data stays on the existing binary sensor
- Covers SSD/HDD/NVMe wear, reallocated sectors, writes, CRC errors, etc.

<img width="417" height="831" alt="SMART" src="https://github.com/user-attachments/assets/f80ed460-2fab-4136-b6ad-49c84e821930" />
